### PR TITLE
Add environment.yml with pinned dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+name: eda_simplifier
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.10
+  - pandas>=2.0
+  - altair>=5.0
+  - numpy>=2.4
+  - pytest>=9.0
+  - hatch>=1.16
+  - pre-commit>=4.3
+  - pytest-cov>=7.0
+  - pytest-randomly>=4.0
+  - pytest-xdist>=3.8
+  - ruff>=0.14
+  - black>=26.1
+
+  # Pip-only packages
+  - pip>=24.0
+  - pip:
+      - quartodoc>=0.11
+      - pytest-raises>=0.11


### PR DESCRIPTION
- [ ] fix #31
- [x] description of feature/fix: Add environment.yml with pinned dependencies
- [x] tests added/passed: Tested the environment and no problems encountered (see log below)
- [ ] add an entry to the [changelog](../CHANGELOG.md)


```
(base) Johnson@DESKTOP-7FC37BL ~/MDS/524/DSCI_524_Group38_EDAsimplifier (env-yml-jc)
$ conda activate eda_simplifier

(eda_simplifier) Johnson@DESKTOP-7FC37BL ~/MDS/524/DSCI_524_Group38_EDAsimplifier (env-yml-jc)
$ pip install -e .
Obtaining file:///C:/Users/Johnson/MDS/524/DSCI_524_Group38_EDAsimplifier
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: altair>=5.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from eda_simplifier==0.1.0) (6.0.0)
Requirement already satisfied: numpy in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from eda_simplifier==0.1.0) (2.4.1)
Requirement already satisfied: pandas>=2.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from eda_simplifier==0.1.0) (3.0.0)
Requirement already satisfied: pytest in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from eda_simplifier==0.1.0) (9.0.2)
Requirement already satisfied: jinja2 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from altair>=5.0->eda_simplifier==0.1.0) (3.1.6)
Requirement already satisfied: jsonschema>=3.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from altair>=5.0->eda_simplifier==0.1.0) (4.26.0)
Requirement already satisfied: narwhals>=1.27.1 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from altair>=5.0->eda_simplifier==0.1.0) (2.15.0)
Requirement already satisfied: packaging in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from altair>=5.0->eda_simplifier==0.1.0) (26.0)
Requirement already satisfied: typing-extensions>=4.12.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from altair>=5.0->eda_simplifier==0.1.0) (4.15.0)
Requirement already satisfied: attrs>=22.2.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from jsonschema>=3.0->altair>=5.0->eda_simplifier==0.1.0) (25.4.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from jsonschema>=3.0->altair>=5.0->eda_simplifier==0.1.0) (2025.9.1)
Requirement already satisfied: referencing>=0.28.4 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from jsonschema>=3.0->altair>=5.0->eda_simplifier==0.1.0) (0.37.0)
Requirement already satisfied: rpds-py>=0.25.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from jsonschema>=3.0->altair>=5.0->eda_simplifier==0.1.0) (0.30.0)
Requirement already satisfied: python-dateutil>=2.8.2 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from pandas>=2.0->eda_simplifier==0.1.0) (2.9.0.post0)
Requirement already satisfied: tzdata in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from pandas>=2.0->eda_simplifier==0.1.0) (2025.3)
Requirement already satisfied: six>=1.5 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from python-dateutil>=2.8.2->pandas>=2.0->eda_simplifier==0.1.0) (1.17.0)
Requirement already satisfied: MarkupSafe>=2.0 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from jinja2->altair>=5.0->eda_simplifier==0.1.0) (3.0.3)
Requirement already satisfied: colorama>=0.4 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from pytest->eda_simplifier==0.1.0) (0.4.6)
Requirement already satisfied: iniconfig>=1.0.1 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from pytest->eda_simplifier==0.1.0) (2.3.0)
Requirement already satisfied: pluggy<2,>=1.5 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from pytest->eda_simplifier==0.1.0) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in c:\users\johnson\miniforge3\envs\eda_simplifier\lib\site-packages (from pytest->eda_simplifier==0.1.0) (2.19.2)
Building wheels for collected packages: eda_simplifier
  Building editable for eda_simplifier (pyproject.toml) ... done
  Created wheel for eda_simplifier: filename=eda_simplifier-0.1.0-py3-none-any.whl size=4419 sha256=8f4628ff8044453140de93aa04a0fc2a0e5965f7b6cdf1b16f2f0c0f42e1bf70
  Stored in directory: C:\Users\Johnson\AppData\Local\Temp\pip-ephem-wheel-cache-bvvqy5mc\wheels\ae\75\f8\13c8702682609420f7691f30dd8a0774c2b9c41a4d418249ac
Successfully built eda_simplifier
Installing collected packages: eda_simplifier
Successfully installed eda_simplifier-0.1.0

(eda_simplifier) Johnson@DESKTOP-7FC37BL ~/MDS/524/DSCI_524_Group38_EDAsimplifier (env-yml-jc)
$ pytest -v
================================================= test session starts =================================================
platform win32 -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0 -- C:\Users\Johnson\miniforge3\envs\eda_simplifier\python.exe
cachedir: .pytest_cache
Using --randomly-seed=4200836664
rootdir: C:\Users\Johnson\MDS\524\DSCI_524_Group38_EDAsimplifier
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.12.1, cov-7.0.0, raises-0.11, randomly-4.0.1, xdist-3.8.0
collected 26 items

tests/unit/test_numeric.py::test_numeric PASSED                                                                  [  3%]
tests/unit/test_numeric.py::test_numeric_with_negative_values PASSED                                             [  7%]
tests/unit/test_numeric.py::test_no_missing_values PASSED                                                        [ 11%]
tests/unit/test_numeric.py::test_empty_dataframe PASSED                                                          [ 15%]
tests/unit/test_numeric.py::test_single_numeric_column PASSED                                                    [ 19%]
tests/unit/test_numeric.py::test_target_not_string PASSED                                                        [ 23%]
tests/unit/test_numeric.py::test_nonexistent_target PASSED                                                       [ 26%]
tests/unit/test_numeric.py::test_numeric_with_integer_columns PASSED                                             [ 30%]
tests/unit/test_numeric.py::test_df_not_dataframe PASSED                                                         [ 34%]
tests/unit/test_ambiguous_columns_split.py::test_override_categorical_to_numeric PASSED                          [ 38%]
tests/unit/test_ambiguous_columns_split.py::test_basic_separation PASSED                                         [ 42%]
tests/unit/test_ambiguous_columns_split.py::test_override_numeric_to_categorical PASSED                          [ 46%]
tests/unit/test_ambiguous_columns_split.py::test_conflict_raises_error PASSED                                    [ 50%]
tests/unit/test_ambiguous_columns_split.py::test_invalid_columns_ignored PASSED                                  [ 53%]
tests/unit/test_ambiguous_columns_split.py::test_none_ambiguous_columns PASSED                                   [ 57%]
tests/unit/test_all_distribution.py::test_all_distributions_with_max_categories PASSED                           [ 61%]
tests/unit/test_all_distribution.py::test_all_distributions_basic PASSED                                         [ 65%]
tests/unit/test_all_distribution.py::test_all_distributions_with_ambiguous_override PASSED                       [ 69%]
tests/unit/test_all_distribution.py::test_all_distributions_with_categorical_features PASSED                     [ 73%]
tests/unit/test_all_distribution.py::test_all_distributions_empty_dataframe PASSED                               [ 76%]
tests/unit/test_categorical_plot.py::test_categorical_plot PASSED                                                [ 80%]
tests/unit/test_dataset_overview.py::test_empty_dataframe_returns_empty_structures PASSED                        [ 84%]
tests/unit/test_dataset_overview.py::test_numeric_columns_include_summary_statistics PASSED                      [ 88%]
tests/unit/test_dataset_overview.py::test_raises_type_error_for_non_dataframe PASSED                             [ 92%]
tests/unit/test_dataset_overview.py::test_dataframe_with_no_numeric_columns PASSED                               [ 96%]
tests/unit/test_dataset_overview.py::test_returns_expected_keys PASSED                                           [100%]

================================================= 26 passed in 5.05s ==================================================

(eda_simplifier) Johnson@DESKTOP-7FC37BL ~/MDS/524/DSCI_524_Group38_EDAsimplifier (env-yml-jc)
$ ruff check .
All checks passed!

(eda_simplifier) Johnson@DESKTOP-7FC37BL ~/MDS/524/DSCI_524_Group38_EDAsimplifier (env-yml-jc)
$ black --check .
All done! ✨ 🍰 ✨
8 files would be left unchanged.

```